### PR TITLE
feat(rounds): add round service

### DIFF
--- a/PancakeSwap.Application/Database/Repository/IBetRepository.cs
+++ b/PancakeSwap.Application/Database/Repository/IBetRepository.cs
@@ -12,7 +12,7 @@ namespace PancakeSwap.Application.Database.Repository
     /// <summary>
     /// 下注仓库接口
     /// </summary>
-    public interface IBetRepository : IBaseRepository<BetEntity> , ITransientDependency
+    public interface IBetRepository : IBaseRepository<BetEntity>, ITransientDependency
     {
 
     }

--- a/PancakeSwap.Application/Database/Repository/IRoundRepository.cs
+++ b/PancakeSwap.Application/Database/Repository/IRoundRepository.cs
@@ -12,7 +12,7 @@ namespace PancakeSwap.Application.Database.Repository
     /// <summary>
     /// 每回合的仓库接口
     /// </summary>
-    public interface IRoundRepository : IBaseRepository<BetEntity>, ITransientDependency
+    public interface IRoundRepository : IBaseRepository<RoundEntity>, ITransientDependency
     {
 
     }

--- a/PancakeSwap.Application/Enums/BetPosition.cs
+++ b/PancakeSwap.Application/Enums/BetPosition.cs
@@ -1,0 +1,18 @@
+namespace PancakeSwap.Application.Enums
+{
+    /// <summary>
+    /// 下注方向。
+    /// </summary>
+    public enum BetPosition
+    {
+        /// <summary>
+        /// 看涨。
+        /// </summary>
+        Bull = 0,
+
+        /// <summary>
+        /// 看跌。
+        /// </summary>
+        Bear = 1
+    }
+}

--- a/PancakeSwap.Application/Enums/RoundStatus.cs
+++ b/PancakeSwap.Application/Enums/RoundStatus.cs
@@ -1,0 +1,23 @@
+namespace PancakeSwap.Application.Enums
+{
+    /// <summary>
+    /// 表示回合的当前状态。
+    /// </summary>
+    public enum RoundStatus
+    {
+        /// <summary>
+        /// 已创建但尚未锁定。
+        /// </summary>
+        Pending = 0,
+
+        /// <summary>
+        /// 已锁定，等待结算。
+        /// </summary>
+        Locked = 1,
+
+        /// <summary>
+        /// 已结束并写入收盘价。
+        /// </summary>
+        Ended = 2
+    }
+}

--- a/PancakeSwap.Application/Services/IRoundService.cs
+++ b/PancakeSwap.Application/Services/IRoundService.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PancakeSwap.Application.Services
+{
+    /// <summary>
+    /// 定义回合相关的业务操作。
+    /// </summary>
+    public interface IRoundService
+    {
+        /// <summary>
+        /// 创建下一回合并返回其 Epoch。
+        /// </summary>
+        /// <param name="ct">取消标记。</param>
+        /// <returns>新回合的 Epoch。</returns>
+        Task<long> CreateNextRoundAsync(CancellationToken ct);
+
+        /// <summary>
+        /// 锁定指定回合并写入锁仓价。
+        /// </summary>
+        /// <param name="epoch">回合编号。</param>
+        /// <param name="ct">取消标记。</param>
+        Task LockRoundAsync(long epoch, CancellationToken ct);
+
+        /// <summary>
+        /// 结算指定回合并写入收盘价与状态。
+        /// </summary>
+        /// <param name="epoch">回合编号。</param>
+        /// <param name="ct">取消标记。</param>
+        Task SettleRoundAsync(long epoch, CancellationToken ct);
+    }
+}

--- a/PancakeSwap.Infrastructure/Services/RoundService.cs
+++ b/PancakeSwap.Infrastructure/Services/RoundService.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Nethereum.Web3;
+using PancakeSwap.Application.Database.Entities;
+using PancakeSwap.Application.Enums;
+using PancakeSwap.Application.Services;
+using PancakeSwap.Infrastructure.Database;
+using SqlSugar;
+
+namespace PancakeSwap.Infrastructure.Services
+{
+    /// <summary>
+    /// 回合业务实现。
+    /// </summary>
+    public class RoundService : IRoundService
+    {
+        private const string LatestAnswerAbi =
+            "[{\"inputs\":[],\"name\":\"latestAnswer\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]";
+
+        private readonly ApplicationDbContext _context;
+        private readonly IWeb3 _web3;
+        private readonly string _oracleAddress;
+
+        /// <summary>
+        /// 初始化服务实例。
+        /// </summary>
+        /// <param name="context">数据库上下文。</param>
+        /// <param name="web3">Web3 实例。</param>
+        /// <param name="configuration">配置读取实例。</param>
+        public RoundService(ApplicationDbContext context, IWeb3 web3, IConfiguration configuration)
+        {
+            _context = context;
+            _web3 = web3;
+            _oracleAddress = configuration.GetValue<string>("CHAINLINK_ORACLE");
+        }
+
+        /// <inheritdoc />
+        public async Task<long> CreateNextRoundAsync(CancellationToken ct)
+        {
+            var last = await _context.Db.Queryable<RoundEntity>()
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
+                .FirstAsync();
+            var nextEpoch = (last?.Epoch ?? 0) + 1;
+
+            var round = new RoundEntity
+            {
+                Epoch = nextEpoch,
+                StartTime = DateTime.UtcNow,
+                Status = (int)RoundStatus.Pending
+            };
+
+            await _context.Db.Insertable(round).ExecuteCommandAsync();
+            return nextEpoch;
+        }
+
+        /// <inheritdoc />
+        public async Task LockRoundAsync(long epoch, CancellationToken ct)
+        {
+            var price = await FetchLatestPriceAsync();
+
+            await _context.Db.Updateable<RoundEntity>()
+                .SetColumns(r => new RoundEntity
+                {
+                    LockPrice = price,
+                    LockTime = DateTime.UtcNow,
+                    Status = (int)RoundStatus.Locked
+                })
+                .Where(r => r.Epoch == epoch)
+                .ExecuteCommandAsync();
+        }
+
+        /// <inheritdoc />
+        public async Task SettleRoundAsync(long epoch, CancellationToken ct)
+        {
+            var closePrice = await FetchLatestPriceAsync();
+            var round = await _context.Db.Queryable<RoundEntity>()
+                .Where(r => r.Epoch == epoch)
+                .FirstAsync();
+            if (round == null)
+            {
+                return;
+            }
+
+            await _context.Db.Updateable<RoundEntity>()
+                .SetColumns(r => new RoundEntity
+                {
+                    ClosePrice = closePrice,
+                    CloseTime = DateTime.UtcNow,
+                    Status = (int)RoundStatus.Ended
+                })
+                .Where(r => r.Epoch == epoch)
+                .ExecuteCommandAsync();
+        }
+
+        private async Task<decimal> FetchLatestPriceAsync()
+        {
+            var contract = _web3.Eth.GetContract(LatestAnswerAbi, _oracleAddress);
+            var function = contract.GetFunction("latestAnswer");
+            var value = await function.CallAsync<BigInteger>();
+            return (decimal)value / 1_00000000m;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `IRoundService` defining round operations
- implement `RoundService` to manage round lifecycle via SqlSugar and Chainlink
- fix repository generics and whitespace
- add enums for round status and bet position

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6863a24aaeb48323859dcf8232e7f7bd