### PR TITLE
feat(api): add chain event listener

### DIFF
--- a/PancakeSwap.Api/HostedServices/ChainEventListener.cs
+++ b/PancakeSwap.Api/HostedServices/ChainEventListener.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Nethereum.Hex.HexTypes;
+using Nethereum.Web3;
+using PancakeSwap.Application.Services;
+using PancakeSwap.Infrastructure.Blockchain.PancakePredictionV2.ContractDefinition;
+
+namespace PancakeSwap.Api.HostedServices
+{
+    /// <summary>
+    /// 监听 PancakePrediction 合约的 EndRound 事件。
+    /// </summary>
+    public class ChainEventListener : BackgroundService
+    {
+        private readonly IWeb3 _web3;
+        private readonly IRoundService _roundService;
+        private readonly ILogger<ChainEventListener> _logger;
+        private readonly string _contractAddress;
+        private Nethereum.Hex.HexTypes.HexBigInteger? _filterId;
+        private Nethereum.Contracts.Event<EndRoundEventDTO>? _event;
+
+        /// <summary>
+        /// 初始化 <see cref="ChainEventListener"/> 实例。
+        /// </summary>
+        /// <param name="configuration">配置读取器。</param>
+        /// <param name="web3">Web3 实例。</param>
+        /// <param name="roundService">回合服务。</param>
+        /// <param name="logger">日志组件。</param>
+        public ChainEventListener(
+            IConfiguration configuration,
+            IWeb3 web3,
+            IRoundService roundService,
+            ILogger<ChainEventListener> logger)
+        {
+            _web3 = web3;
+            _roundService = roundService;
+            _logger = logger;
+            _contractAddress = configuration.GetValue<string>("PREDICTION_ADDRESS") ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (string.IsNullOrWhiteSpace(_contractAddress))
+            {
+                _logger.LogWarning("PREDICTION_ADDRESS not configured");
+                return;
+            }
+
+            _event = _web3.Eth.GetEvent<EndRoundEventDTO>(_contractAddress);
+            _filterId = await _event.CreateFilterAsync();
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var logs = await _event.GetFilterChangesAsync(_filterId);
+                    foreach (var log in logs)
+                    {
+                        var epoch = (long)log.Event.Epoch;
+                        await _roundService.SettleRoundAsync(epoch, stoppingToken);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing EndRound events");
+                }
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(3), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_event != null && _filterId != null)
+            {
+                try
+                {
+                    await _web3.Eth.Filters.UninstallFilter.SendRequestAsync(_filterId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to uninstall EndRound filter");
+                }
+            }
+
+            await base.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/PancakeSwap.Api/Program.cs
+++ b/PancakeSwap.Api/Program.cs
@@ -1,6 +1,10 @@
 using PancakeSwap.Application.Database.Config;
 using PancakeSwap.Infrastructure.Database;
 using PancakeSwap.Infrastructure.Database.Migrations;
+using PancakeSwap.Application.Services;
+using PancakeSwap.Infrastructure.Services;
+using PancakeSwap.Api.HostedServices;
+using Nethereum.Web3;
 using QYQ.Base.Common.IOCExtensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -10,6 +14,11 @@ builder.AddQYQSerilog();
 builder.Services.AddControllers();
 builder.Services.AddSingleton<ApplicationDbContext>();
 builder.Services.Configure<DatabaseConfig>(builder.Configuration.GetSection("ConnectionStrings:Default"));
+
+var rpc = builder.Configuration.GetValue<string>("BSC_RPC");
+builder.Services.AddSingleton<IWeb3>(_ => new Web3(rpc));
+builder.Services.AddSingleton<IRoundService, RoundService>();
+builder.Services.AddHostedService<ChainEventListener>();
 
 var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install
 
 环境变量：
 - `BSC_TESTNET_RPC`：BSC 测试网 RPC 地址
+- `BSC_RPC`：后台监听事件的 BSC RPC 地址
 - `PRIVATE_KEY`：部署或测试用私钥
 - `PG_CONNECTION`：PostgreSQL 连接字符串
 


### PR DESCRIPTION
## Summary
- add ChainEventListener background service to poll PancakePrediction events
- register Web3, RoundService and ChainEventListener in Api
- document `BSC_RPC` env variable in README

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6863a484da8c8323a117ef574a9bedd8