### PR TITLE
feat/round

### DIFF
--- a/PancakeSwap.Api/Program.cs
+++ b/PancakeSwap.Api/Program.cs
@@ -42,4 +42,4 @@ app.Run();
 /// <summary>
 ///  Required for testing purposes
 /// </summary>
-public partial class Program { } 
+public partial class Program { }

--- a/PancakeSwap.Application/Database/Entities/BetEntity.cs
+++ b/PancakeSwap.Application/Database/Entities/BetEntity.cs
@@ -1,4 +1,5 @@
 using SqlSugar;
+using PancakeSwap.Application.Enums;
 
 namespace PancakeSwap.Application.Database.Entities
 {
@@ -9,22 +10,22 @@ namespace PancakeSwap.Application.Database.Entities
     public class BetEntity
     {
         /// <summary>
-        /// 主键自增编号。
+        /// 主键编号。
         /// </summary>
         [SugarColumn(IsPrimaryKey = true, IsIdentity = true, ColumnName = "id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// 所属回合编号。
         /// </summary>
-        [SugarColumn(ColumnName = "epoch")]
-        public long Epoch { get; set; }
+        [SugarColumn(ColumnName = "epoch_id")]
+        public long EpochId { get; set; }
 
         /// <summary>
         /// 用户地址。
         /// </summary>
-        [SugarColumn(ColumnName = "address")]
-        public string Address { get; set; } = string.Empty;
+        [SugarColumn(ColumnName = "user_address")]
+        public string UserAddress { get; set; } = string.Empty;
 
         /// <summary>
         /// 下注金额。
@@ -36,6 +37,18 @@ namespace PancakeSwap.Application.Database.Entities
         /// 下注方向。
         /// </summary>
         [SugarColumn(ColumnName = "position")]
-        public int Position { get; set; }
+        public Position Position { get; set; }
+
+        /// <summary>
+        /// 是否已领取奖励。
+        /// </summary>
+        [SugarColumn(ColumnName = "claimed")]
+        public bool Claimed { get; set; }
+
+        /// <summary>
+        /// 奖励金额。
+        /// </summary>
+        [SugarColumn(ColumnName = "reward", ColumnDataType = "decimal(18,8)")]
+        public decimal Reward { get; set; }
     }
 }

--- a/PancakeSwap.Application/Database/Entities/PriceSnapshotEntity.cs
+++ b/PancakeSwap.Application/Database/Entities/PriceSnapshotEntity.cs
@@ -1,0 +1,30 @@
+using System;
+using SqlSugar;
+
+namespace PancakeSwap.Application.Database.Entities
+{
+    /// <summary>
+    /// 价格快照记录。
+    /// </summary>
+    [SugarTable("price_snapshot")]
+    public class PriceSnapshotEntity
+    {
+        /// <summary>
+        /// 主键编号。
+        /// </summary>
+        [SugarColumn(IsPrimaryKey = true, IsIdentity = true, ColumnName = "id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// 时间戳。
+        /// </summary>
+        [SugarColumn(ColumnName = "timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// 当前价格。
+        /// </summary>
+        [SugarColumn(ColumnName = "price", ColumnDataType = "decimal(18,8)")]
+        public decimal Price { get; set; }
+    }
+}

--- a/PancakeSwap.Application/Database/Entities/RoundEntity.cs
+++ b/PancakeSwap.Application/Database/Entities/RoundEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using SqlSugar;
+using PancakeSwap.Application.Enums;
 
 namespace PancakeSwap.Application.Database.Entities
 {
@@ -12,8 +13,8 @@ namespace PancakeSwap.Application.Database.Entities
         /// <summary>
         /// 回合编号。
         /// </summary>
-        [SugarColumn(IsPrimaryKey = true, IsIdentity = false, ColumnName = "epoch")]
-        public long Epoch { get; set; }
+        [SugarColumn(IsPrimaryKey = true, IsIdentity = false, ColumnName = "id")]
+        public long Id { get; set; }
 
         /// <summary>
         /// 回合开始时间。
@@ -46,10 +47,16 @@ namespace PancakeSwap.Application.Database.Entities
         public decimal ClosePrice { get; set; }
 
         /// <summary>
+        /// 当前价格。
+        /// </summary>
+        [SugarColumn(ColumnName = "current_price", ColumnDataType = "decimal(18,8)")]
+        public decimal CurrentPrice { get; set; }
+
+        /// <summary>
         /// 回合状态。
         /// </summary>
         [SugarColumn(ColumnName = "status")]
-        public int Status { get; set; }
+        public RoundStatus Status { get; set; }
 
         /// <summary>
         /// 本回合的下注总金额。
@@ -60,19 +67,19 @@ namespace PancakeSwap.Application.Database.Entities
         /// <summary>
         /// 押涨总金额。
         /// </summary>
-        [SugarColumn(ColumnName = "bull_amount", ColumnDataType = "decimal(18,8)")]
-        public decimal BullAmount { get; set; }
+        [SugarColumn(ColumnName = "up_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal UpAmount { get; set; }
 
         /// <summary>
         /// 押跌总金额。
         /// </summary>
-        [SugarColumn(ColumnName = "bear_amount", ColumnDataType = "decimal(18,8)")]
-        public decimal BearAmount { get; set; }
+        [SugarColumn(ColumnName = "down_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal DownAmount { get; set; }
 
         /// <summary>
-        /// 获胜方向，0 表示看涨，1 表示看跌。
+        /// 可分配奖金池。
         /// </summary>
-        [SugarColumn(ColumnName = "winning_position", IsNullable = true)]
-        public int? WinningPosition { get; set; }
+        [SugarColumn(ColumnName = "reward_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal RewardAmount { get; set; }
     }
 }

--- a/PancakeSwap.Application/Enums/Position.cs
+++ b/PancakeSwap.Application/Enums/Position.cs
@@ -1,18 +1,18 @@
 namespace PancakeSwap.Application.Enums
 {
     /// <summary>
-    /// 下注方向。
+    /// 用户下注方向。
     /// </summary>
-    public enum BetPosition
+    public enum Position
     {
         /// <summary>
-        /// 看涨。
+        /// 看涨方向。
         /// </summary>
-        Bull = 0,
+        Up = 0,
 
         /// <summary>
-        /// 看跌。
+        /// 看跌方向。
         /// </summary>
-        Bear = 1
+        Down = 1
     }
 }

--- a/PancakeSwap.Application/Enums/RoundStatus.cs
+++ b/PancakeSwap.Application/Enums/RoundStatus.cs
@@ -1,23 +1,28 @@
 namespace PancakeSwap.Application.Enums
 {
     /// <summary>
-    /// 表示回合的当前状态。
+    /// 回合状态。
     /// </summary>
     public enum RoundStatus
     {
         /// <summary>
-        /// 已创建但尚未锁定。
+        /// 即将开始。
         /// </summary>
-        Pending = 0,
+        Upcoming = 0,
+
+        /// <summary>
+        /// 回合进行中。
+        /// </summary>
+        Live = 1,
 
         /// <summary>
         /// 已锁定，等待结算。
         /// </summary>
-        Locked = 1,
+        Locked = 2,
 
         /// <summary>
-        /// 已结束并写入收盘价。
+        /// 已结束。
         /// </summary>
-        Ended = 2
+        Ended = 3
     }
 }

--- a/PancakeSwap.Infrastructure/Database/Entities/BetEntity.cs
+++ b/PancakeSwap.Infrastructure/Database/Entities/BetEntity.cs
@@ -1,4 +1,5 @@
 using SqlSugar;
+using PancakeSwap.Application.Enums;
 
 namespace PancakeSwap.Infrastructure.Database.Entities
 {
@@ -9,33 +10,45 @@ namespace PancakeSwap.Infrastructure.Database.Entities
     public class BetEntity
     {
         /// <summary>
-        /// 
+        /// Primary key identifier.
         /// </summary>
         [SugarColumn(IsPrimaryKey = true, IsIdentity = true, ColumnName = "id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
-        /// »ØºÏ±àºÅ
+        /// Related round identifier.
         /// </summary>
-        [SugarColumn(ColumnName = "epoch")]
-        public long Epoch { get; set; }
+        [SugarColumn(ColumnName = "epoch_id")]
+        public long EpochId { get; set; }
 
         /// <summary>
-        /// 
+        /// User address.
         /// </summary>
-        [SugarColumn(ColumnName = "address")]
-        public string Address { get; set; } = string.Empty;
+        [SugarColumn(ColumnName = "user_address")]
+        public string UserAddress { get; set; } = string.Empty;
 
         /// <summary>
-        /// 
+        /// Bet amount.
         /// </summary>
         [SugarColumn(ColumnName = "amount", ColumnDataType = "decimal(18,8)")]
         public decimal Amount { get; set; }
 
         /// <summary>
-        /// 
+        /// Bet position.
         /// </summary>
         [SugarColumn(ColumnName = "position")]
-        public int Position { get; set; }
+        public Position Position { get; set; }
+
+        /// <summary>
+        /// Whether the reward has been claimed.
+        /// </summary>
+        [SugarColumn(ColumnName = "claimed")]
+        public bool Claimed { get; set; }
+
+        /// <summary>
+        /// Reward amount.
+        /// </summary>
+        [SugarColumn(ColumnName = "reward", ColumnDataType = "decimal(18,8)")]
+        public decimal Reward { get; set; }
     }
 }

--- a/PancakeSwap.Infrastructure/Database/Entities/PriceSnapshotEntity.cs
+++ b/PancakeSwap.Infrastructure/Database/Entities/PriceSnapshotEntity.cs
@@ -1,0 +1,30 @@
+using System;
+using SqlSugar;
+
+namespace PancakeSwap.Infrastructure.Database.Entities
+{
+    /// <summary>
+    ///     Price snapshot entity.
+    /// </summary>
+    [SugarTable("price_snapshots")]
+    public class PriceSnapshotEntity
+    {
+        /// <summary>
+        /// Primary key identifier.
+        /// </summary>
+        [SugarColumn(IsPrimaryKey = true, IsIdentity = true, ColumnName = "id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Snapshot timestamp.
+        /// </summary>
+        [SugarColumn(ColumnName = "timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Price value.
+        /// </summary>
+        [SugarColumn(ColumnName = "price", ColumnDataType = "decimal(18,8)")]
+        public decimal Price { get; set; }
+    }
+}

--- a/PancakeSwap.Infrastructure/Database/Entities/RoundEntity.cs
+++ b/PancakeSwap.Infrastructure/Database/Entities/RoundEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using SqlSugar;
+using PancakeSwap.Application.Enums;
 
 namespace PancakeSwap.Infrastructure.Database.Entities
 {
@@ -10,10 +11,10 @@ namespace PancakeSwap.Infrastructure.Database.Entities
     public class RoundEntity
     {
         /// <summary>
-        ///     Epoch identifier.
+        ///     Round identifier.
         /// </summary>
-        [SugarColumn(IsPrimaryKey = true, IsIdentity = false, ColumnName = "epoch")]
-        public long Epoch { get; set; }
+        [SugarColumn(IsPrimaryKey = true, IsIdentity = false, ColumnName = "id")]
+        public long Id { get; set; }
 
         [SugarColumn(ColumnName = "start_time")]
         public DateTime StartTime { get; set; }
@@ -30,22 +31,22 @@ namespace PancakeSwap.Infrastructure.Database.Entities
         [SugarColumn(ColumnName = "close_price", ColumnDataType = "decimal(18,8)")]
         public decimal ClosePrice { get; set; }
 
+        [SugarColumn(ColumnName = "current_price", ColumnDataType = "decimal(18,8)")]
+        public decimal CurrentPrice { get; set; }
+
         [SugarColumn(ColumnName = "status")]
-        public int Status { get; set; }
+        public RoundStatus Status { get; set; }
 
         [SugarColumn(ColumnName = "total_amount", ColumnDataType = "decimal(18,8)")]
         public decimal TotalAmount { get; set; }
 
-        [SugarColumn(ColumnName = "bull_amount", ColumnDataType = "decimal(18,8)")]
-        public decimal BullAmount { get; set; }
+        [SugarColumn(ColumnName = "up_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal UpAmount { get; set; }
 
-        [SugarColumn(ColumnName = "bear_amount", ColumnDataType = "decimal(18,8)")]
-        public decimal BearAmount { get; set; }
+        [SugarColumn(ColumnName = "down_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal DownAmount { get; set; }
 
-        /// <summary>
-        /// 获胜方向，0 表示看涨，1 表示看跌。
-        /// </summary>
-        [SugarColumn(ColumnName = "winning_position", IsNullable = true)]
-        public int? WinningPosition { get; set; }
+        [SugarColumn(ColumnName = "reward_amount", ColumnDataType = "decimal(18,8)")]
+        public decimal RewardAmount { get; set; }
     }
 }

--- a/PancakeSwap.Infrastructure/Database/Migrations/InitMigration.cs
+++ b/PancakeSwap.Infrastructure/Database/Migrations/InitMigration.cs
@@ -14,7 +14,7 @@ namespace PancakeSwap.Infrastructure.Database.Migrations
         /// <param name="db">SqlSugar client.</param>
         public static void Run(ISqlSugarClient db)
         {
-            db.CodeFirst.InitTables<RoundEntity, BetEntity>();
+            db.CodeFirst.InitTables<RoundEntity, BetEntity, PriceSnapshotEntity>();
         }
     }
 }

--- a/PancakeSwap.Test/RoundServiceTests.cs
+++ b/PancakeSwap.Test/RoundServiceTests.cs
@@ -28,9 +28,9 @@ public class RoundServiceTests(WebApplicationFactory<Program> factory) : IClassF
         var context = _serviceProvider.GetRequiredService<ApplicationDbContext>();
         await context.Db.Insertable(new RoundEntity
         {
-            Epoch = 1,
+            Id = 1,
             LockPrice = 10,
-            Status = (int)RoundStatus.Locked,
+            Status = RoundStatus.Locked,
             StartTime = DateTime.UtcNow,
             LockTime = DateTime.UtcNow,
             CloseTime = DateTime.UtcNow
@@ -50,9 +50,9 @@ public class RoundServiceTests(WebApplicationFactory<Program> factory) : IClassF
         var context = _serviceProvider.GetRequiredService<ApplicationDbContext>();
         await context.Db.Insertable(new RoundEntity
         {
-            Epoch = 1,
+            Id = 1,
             LockPrice = 10,
-            Status = (int)RoundStatus.Locked,
+            Status = RoundStatus.Locked,
             StartTime = DateTime.UtcNow,
             LockTime = DateTime.UtcNow,
             CloseTime = DateTime.UtcNow
@@ -65,7 +65,7 @@ public class RoundServiceTests(WebApplicationFactory<Program> factory) : IClassF
 
         await service.SettleRoundAsync(1, CancellationToken.None);
 
-        var round = await context.Db.Queryable<RoundEntity>().Where(r => r.Epoch == 1).FirstAsync();
-        Assert.Equal((int)BetPosition.Bull, round.WinningPosition);
+        var round = await context.Db.Queryable<RoundEntity>().Where(r => r.Id == 1).FirstAsync();
+        Assert.Equal(RoundStatus.Ended, round.Status);
     }
 }


### PR DESCRIPTION
## Summary
- update RoundStatus enum to include upcoming/live/locked/ended states
- rename BetPosition to Position enum
- extend round and bet entities with new fields
- add price snapshot entity
- revise round service and tests for new entities

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test` *(fails: Can't find 'testhost.deps.json')*

------
https://chatgpt.com/codex/tasks/task_e_6863b58161388323a9db4e1c4c8f06c4