### PR TITLE
feat/worker

### DIFF
--- a/PancakeSwap.Infrastructure/PancakeSwap.Infrastructure.csproj
+++ b/PancakeSwap.Infrastructure/PancakeSwap.Infrastructure.csproj
@@ -10,6 +10,9 @@
     <ProjectReference Include="..\PancakeSwap.Application\PancakeSwap.Application.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Blockchain\PancakePredictionV2.abi" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
     <PackageReference Include="Nethereum.Web3" Version="5.0.0" />
     <PackageReference Include="QYQ.Base.SqlSugar" Version="8.2.3" />


### PR DESCRIPTION
## Summary
- support genesis rounds when running ExecuteRoundWorker on local development
- embed contract ABI resource for contract connection

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test` *(fails: Can't find `testhost.deps.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6864b3d8126c83238cbb754a4b601ded