### PR TITLE
fix(worker): handle oracle revert

### DIFF
--- a/PancakeSwap.Infrastructure/HostedServices/ExecuteRoundWorker.cs
+++ b/PancakeSwap.Infrastructure/HostedServices/ExecuteRoundWorker.cs
@@ -225,6 +225,11 @@ namespace PancakeSwap.Infrastructure.HostedServices
                     _logger.LogWarning("⌛ 太早，15 秒后重试");
                     await SleepOrFastForward(15, token);
                 }
+                catch (SmartContractRevertException ex) when (ex.RevertMessage.Contains("roundId must be larger than oracleLatestRoundId"))
+                {
+                    _logger.LogWarning("📈 预言机数据未更新，30 秒后重试");
+                    await SleepOrFastForward(30, token);
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "executeRound 调用失败");


### PR DESCRIPTION
## Summary
- handle `roundId must be larger than oracleLatestRoundId` revert in ExecuteRoundWorker

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test` *(fails: Can't find testhost.deps.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864eb52f33c8323a5f4eae71c0220b4