### PR TITLE
fix/contract-env

### DIFF
--- a/PancakeSwap.Infrastructure/HostedServices/ExecuteRoundWorker.cs
+++ b/PancakeSwap.Infrastructure/HostedServices/ExecuteRoundWorker.cs
@@ -47,7 +47,10 @@ namespace PancakeSwap.Infrastructure.HostedServices
             // 读取环境变量
             var rpc = configuration["BSC_RPC"] ?? "http://127.0.0.1:8545";
             var pk = configuration["OPERATOR_PK"] ?? throw new("OPERATOR_PK 未配置");
-            var contract = configuration["PREDICTION_ADDRESS"] ?? throw new("PREDICTION_ADDRESS 未配置");
+            var contract = configuration["PREDICTION_ADDRESS"]
+                           ?? configuration["CONTRACT_ADDR_LOCAL"]
+                           ?? throw new("PREDICTION_ADDRESS 未配置");
+            contract = contract.Trim();
             var mockOracle = configuration["MOCK_ORACLE_ADDR"];
 
             // 创建签名账号

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm install
 - `OPERATOR`：负责执行的运营者地址
 - `BSC_RPC`：后台监听事件的 BSC RPC 地址
 - `OPERATOR_PK`：运营者私钥
+- `PREDICTION_ADDRESS`：Prediction 合约地址（优先使用）
 - `CONTRACT_ADDR_LOCAL`：本地部署的合约地址
 - `MOCK_ORACLE_ADDR`：本地 Mock 预言机地址
 - `INTERVAL_SECONDS`：回合时间间隔


### PR DESCRIPTION
## Summary
- support `CONTRACT_ADDR_LOCAL` fallback for prediction address
- document `PREDICTION_ADDRESS` env variable

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test` *(failed: Can't find 'testhost.deps.json')*

------
https://chatgpt.com/codex/tasks/task_e_6865faee52708323a672d21406dd8069